### PR TITLE
minor updates...

### DIFF
--- a/hacks/intro-to-gke/README.md
+++ b/hacks/intro-to-gke/README.md
@@ -57,13 +57,15 @@ We begin our journey by creating the Kubernetes cluster that will run our new co
 
 ### Description
 
-In this challenge, you will create a single GKE cluster as per these specifications:
+In this challenge, you will create a single *Standard* GKE cluster as per these specifications:
 
 - An initial node pool of machine type: `n1-standard-2`
 - An initial node pool size of 3
 - Located in a GCP zone near you
 
 > **Note** Although you can create this cluster using the Google Cloud Console UI, we encourage you to explore and figure out how to create clusters using the `gcloud` CLI tool.
+
+> **Note** Creating a cluster will take 5-7 minutes.
 
 ### Success Criteria
 
@@ -72,9 +74,12 @@ In this challenge, you will create a single GKE cluster as per these specificati
 
 ### Learning Resources
 
-- [Kubernetes Overview](https://kubernetes.io/docs/concepts/overview/)
 - [GKE Overview](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview)
 - [Zonal Clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster)
+
+## Tips
+
+- Keep in mind that you need to get the credentials to connect `kubectl` to your cluster.
 
 ## Challenge 2: 
 
@@ -139,7 +144,7 @@ We will create yaml files describing the Deployment and Service resources you wi
 Your Deployment resource will need to:
 - Use the container image that we built and pushed to your docker repository in Artifact Registry.
 - Deploy only 1 replica of our container
-- Expose the container on port 80
+- Expose the container on port 8080
 - Use an appropriate label to identify the pod
 
 Your Service resource will need to:

--- a/hacks/intro-to-gke/solutions.md
+++ b/hacks/intro-to-gke/solutions.md
@@ -242,7 +242,7 @@ spec:
       - name: monolith
         image: us-central1-docker.pkg.dev/my-project/dev/monolith:1.0.0
         ports:
-        - containerPort: 80
+        - containerPort: 8080
 ```
 
 > **Note** Make sure that you replace the image path with the exact one from your Artifact Registry docker repository.


### PR DESCRIPTION
Small edits, since Autopilot is the default mode (at least in the UI), I think it makes sense explicitly specify the type of the cluster. And also, the `containerPort` parameter needs to be set to the (to be) exposed port of the container (which is informative anyway), requesting it to be set to the final service port is confusing.