### PR TITLE
Enable copy button on code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ minimal_mistakes_skin: dark
 google_analytics:
 logo: /assets/images/gh-logo.png
 title: ""
+enable_copy_code_button: true
 #subtitle: "Learning By Doing on Google Cloud"
 defaults:
   - scope:


### PR DESCRIPTION
To enable a copy button on code blocks for ease of use during a gHack when following the documentation online. Assuming this works from the following documentation:
https://mmistakes.github.io/minimal-mistakes/docs/configuration/#code-block-copy-button