### PR TITLE
Gh actions upgrades

### DIFF
--- a/.github/workflows/forkpages.yml
+++ b/.github/workflows/forkpages.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Fix the base url
         run: |
           echo "baseurl: ${GITHUB_EVENT_REPOSITORY_NAME}" >> _config.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Split the files 
         run: |
           tools/setup-pages.sh
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 16
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -43,11 +39,11 @@ jobs:
           NOKOGIRI_USE_SYSTEM_LIBRARIES=true bundle install --quiet --gemfile=tools/Gemfile
           github-pages build --source=dist        
       - name: Set up Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: '_site'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'GoogleCloudPlatform/cloud-hackathons'
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set branch specific variables
       id: environment
       run: |
@@ -24,10 +24,6 @@ jobs:
     - name: Split the files 
       run: |
         tools/setup-pages.sh
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 16
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -37,10 +33,10 @@ jobs:
         NOKOGIRI_USE_SYSTEM_LIBRARIES=true bundle install --quiet --gemfile=tools/Gemfile
         github-pages build --source=dist
     - name: GCP Login
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
     - name: Publish to GCS
       run: gcloud storage rsync _site ${{ secrets[steps.environment.outputs.BRANCH_SPECIFIC_BUCKET_NAME] }} --delete-unmatched-destination-objects --recursive

--- a/.github/workflows/scaffold.yaml
+++ b/.github/workflows/scaffold.yaml
@@ -33,7 +33,7 @@ jobs:
       TITLE: ${{ github.event.inputs.hackTitle }}
       NETWORKING: ${{ github.event.inputs.networking }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create new branch
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Markdown lint
-      uses: DavidAnson/markdownlint-cli2-action@v17
+      uses: DavidAnson/markdownlint-cli2-action@v23
       with:
         globs: |
           **/*.md

--- a/hacks/genai-intro/README.md
+++ b/hacks/genai-intro/README.md
@@ -82,9 +82,9 @@ For this challenge we'll use Gemini to determine what the title (including any s
 - Less than 2500 tokens are used to determine the title.
 - The following papers should yield the corresponding titles, you can see those in the `Logs` section of the Cloud Run Function. Make sure that only the title is output:
 
-  | Paper                                           | Title |
-  | ---                                             | ---   |
-  | [LOFAR paper](https://arxiv.org/pdf/2309.00102) | *The LOFAR Two-Metre Sky Survey (LOTSS) VI. Optical identifications for the second data release*|
+  | Paper | Title |
+  | --- | --- |
+  | [LOFAR paper](https://arxiv.org/pdf/2309.00102) | *The LOFAR Two-Metre Sky Survey (LOTSS) VI. Optical identifications for the second data release* |
   | [PEARL paper](https://arxiv.org/pdf/2309.00031) | *PEARLS: Near Infrared Photometry in the JWST North Ecliptic Pole Time Domain Field* |
 
 ### Learning Resources
@@ -179,7 +179,7 @@ Upload the following papers to Cloud Storage Bucket and run your SQL query in Bi
 - Running the SQL query yields the following results
 
   | Title | Category |
-  | ---   | ---      |
+  | --- | --- |
   | From particles to orbits: precise dark matter density profiles using dynamical information | Astrophysics |
   | Bayesian inference methodology to characterize the dust emissivity at far-infrared and submillimeter frequencies | Astrophysics |
   | Computing Twin-Width Parameterized by the Feedback Edge Number | Computer Science |

--- a/hacks/httf-data/README.md
+++ b/hacks/httf-data/README.md
@@ -61,15 +61,15 @@ Create a new *Spanner Enterprise edition* instance called `onlineboutique` with 
 - All the data from the MySQL database `ecom` is migrated to the new Spanner database.
 - Verify that the following tables with the corresponding row counts exist in the new Spanner database:
 
-  | Table | #Rows |
-  | ---   | ---   |
-  | distribution_centers | 10  |
+  | Table                | #Rows   |
+  | ---                  | ---     |
+  | distribution_centers | 10      |
   | events               | 2438862 |
-  | inventory_items      | 494254 |
-  | order_items          | 182905 |
-  | orders               | 125905 |  
-  | products             | 29120 |
-  | users                | 100000 |
+  | inventory_items      | 494254  |
+  | order_items          | 182905  |
+  | orders               | 125905  |  
+  | products             | 29120   |
+  | users                | 100000  |
 
 ### Learning Resources
 
@@ -98,15 +98,15 @@ Copy each table from the Spanner database to the newly created BigQuery dataset.
 - All the data from the Spanner database `ecom` is exported to the new BigQuery dataset.
 - Verify that the following tables with the corresponding row counts exist in the new BigQuery dataset:
 
-  | Table | #Rows |
-  | ---   | ---   |
-  | distribution_centers | 10  |
+  | Table                | #Rows   |
+  | ---                  | ---     |
+  | distribution_centers | 10      |
   | events               | 2438862 |
-  | inventory_items      | 494254 |
-  | order_items          | 182905 |
-  | orders               | 125905 |  
-  | products             | 29120 |
-  | users                | 100000 |
+  | inventory_items      | 494254  |
+  | order_items          | 182905  |
+  | orders               | 125905  |  
+  | products             | 29120   |
+  | users                | 100000  |
 
 ### Learning Resources
 

--- a/hacks/httf-data/solutions.md
+++ b/hacks/httf-data/solutions.md
@@ -451,7 +451,7 @@ gcloud storage cp image-generation-pipeline.yaml $BUCKET
 Now you can pick the `yaml` file from the UI, and provide the following parameters (replace the variables with their values).
 
 | Parameter | Value |
-| ---       | --- |
+| --- | --- |
 | dataset_id | `$BQ_DATASET` |
 | location | `$REGION` |
 | output_bucket | `$BUCKET/product_images` |

--- a/hacks/media-on-gcp/artifacts/infra/norsk-ai/stable/README.md
+++ b/hacks/media-on-gcp/artifacts/infra/norsk-ai/stable/README.md
@@ -13,7 +13,7 @@ terraform plan --var-file marketplace_test.tfvars --var project_id=<YOUR_PROJECT
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
+| ------ | ------------- | ------ | --------- | ---------- |
 | project_id | The ID of the project in which to provision resources. | `string` | `null` | yes |
 | goog_cm_deployment_name | The name of the deployment and VM instance. | `string` | `null` | yes |
 | source_image | The image name for the disk for the VM instance. | `string` | `"projects/id3as-public/global/images/norsk-studio-byol-debian-12-x86-64-2025-05-13"` | no |
@@ -43,7 +43,7 @@ terraform plan --var-file marketplace_test.tfvars --var project_id=<YOUR_PROJECT
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ------ | ------------- |
 | site_url | Site Url |
 | admin_user | Username for Admin password. |
 | admin_password | Password for Admin. |

--- a/hacks/media-on-gcp/artifacts/infra/norsk-gw/stable/README.md
+++ b/hacks/media-on-gcp/artifacts/infra/norsk-gw/stable/README.md
@@ -13,7 +13,7 @@ terraform plan --var-file marketplace_test.tfvars --var project_id=<YOUR_PROJECT
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
+| ------ | ------------- | ------ | --------- | ---------- |
 | project_id | The ID of the project in which to provision resources. | `string` | `null` | yes |
 | goog_cm_deployment_name | The name of the deployment and VM instance. | `string` | `null` | yes |
 | source_image | The image name for the disk for the VM instance. | `string` | `"projects/id3as-public/global/images/norsk-studio-byol-debian-12-x86-64-2025-05-13"` | no |
@@ -43,7 +43,7 @@ terraform plan --var-file marketplace_test.tfvars --var project_id=<YOUR_PROJECT
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ------ | ------------- |
 | site_url | Site Url |
 | admin_user | Username for Admin password. |
 | admin_password | Password for Admin. |

--- a/hacks/mlops-on-gcp/solutions.md
+++ b/hacks/mlops-on-gcp/solutions.md
@@ -126,13 +126,13 @@ The generated json file can be copied to the default GCS bucket (created as part
 
 The parameters for the Vertex AI Pipeline Job:
 
-| Parameter            | Value |
-| ---                  | ---   |
-| GCS output directory | `gs://{PROJECT_ID}/pipelines`|
-| endpoint             | `[none]`  |
-| location             | `us-central1` |
-| project\_id          | `{PROJECT_ID}`|
-| python\_pkg          | `gcp_mlops_demo-0.8.0.dev0.tar.gz`|
+| Parameter            | Value                              |
+| ---                  | ---                                |
+| GCS output directory | `gs://{PROJECT_ID}/pipelines`      |
+| endpoint             | `[none]`                           |
+| location             | `us-central1`                      |
+| project\_id          | `{PROJECT_ID}`                     |
+| python\_pkg          | `gcp_mlops_demo-0.8.0.dev0.tar.gz` |
 
 The `python_pkg` parameter can also be the full path to the package, and also works without the `tar.gz` extension. `GCS output directory` could also be any folder in the bucket (no trailing `/` characters though).
 
@@ -249,11 +249,11 @@ Setting this up through the UI should be trivial, the training sample data uri s
 
 The *retraining* (`clouddeploy.yaml`) build pipeline requires the following variables to be set.
 
-| Variable                  | Value |
-| ---                       | ---   |
-| \_PYTHON\_PKG             | `gcp_mlops_demo-0.8.0.dev0` |
-| \_ENDPOINT                | `ep-taxi-tips` |
-| \_LOCATION                | `us-central1` |
+| Variable      | Value                       |
+| ---           | ---                         |
+| `_PYTHON_PKG` | `gcp_mlops_demo-0.8.0.dev0` |
+| `_ENDPOINT`   | `ep-taxi-tips`              |
+| `_LOCATION`   | `us-central1`               |
 
 The *retraining* pipeline must respond to a *Pub/Sub message* using the topic created for the notification channel.
 
@@ -261,13 +261,13 @@ The *retraining* pipeline must respond to a *Pub/Sub message* using the topic cr
 
 The main challenge is to configure the build pipelines properly. You'll need the following variables for the *batch predictions* (`batchdeploy.yaml`) pipeline. This pipeline must have a *webhook event* trigger.
 
-| Variable                  | Value |
-| ---                       | ---   |
-| \_PYTHON\_PKG             | `gcp_mlops_demo-0.8.0.dev0` |
-| \_MODEL\_NAME             | `taxi-tips`   |
-| \_SOURCE\_TABLE\_URI      | `bq://{PROJECT_ID}.{DATASET}.{TABLE}` |
-| \_TRAINING\_SAMPLE\_URI   | `gs://{PROJECT_ID}/data/sample/sample.csv`|
-| \_LOCATION                | `us-central1` |
+| Variable                | Value                                      |
+| ---                     | ---                                        |
+| `_PYTHON_PKG`           | `gcp_mlops_demo-0.8.0.dev0`                |
+| `_MODEL_NAME`           | `taxi-tips`                                |
+| `_SOURCE_TABLE_URI`     | `bq://{PROJECT_ID}.{DATASET}.{TABLE}`      |
+| `_TRAINING_SAMPLE_URI`  | `gs://{PROJECT_ID}/data/sample/sample.csv` |
+| `_LOCATION`             | `us-central1`                              |
 
 The Cloud Scheduler cron job configuration should be: `30 3 * * 7` with HTTP target type and webhook URL from the previous build configuration, using the POST method (see the note around the webhook URL in [Online Loop](#online-loop) section if you get 404s). One thing to remember is to set the *Content-Type* header to *application/json* otherwise the execution will fail.
 
@@ -275,10 +275,10 @@ You can verify the Cloud Scheduler job by a *Force run*.
 
 Similarly the *retraining* (`clouddeploy.yaml`) build pipeline requires the following variables to be set.
 
-| Variable                  | Value |
-| ---                       | ---   |
-| \_PYTHON\_PKG             | `gcp_mlops_demo-0.8.0.dev0` |
-| \_ENDPOINT                | `[none]` |
-| \_LOCATION                | `us-central1` |
+| Variable       | Value                       |
+| ---            | ---                         |
+| `_PYTHON_PKG`  | `gcp_mlops_demo-0.8.0.dev0` |
+| `_ENDPOINT`    | `[none]`                    |
+| `_LOCATION`    | `us-central1`               |
 
 The *retraining* pipeline must respond to a *Pub/Sub message* using the topic created for the notification channel.

--- a/hacks/realtime-analytics/solutions.md
+++ b/hacks/realtime-analytics/solutions.md
@@ -119,7 +119,7 @@ The subnet needs to be in format `regions/${REGION}/subnetworks/${subnet}`
 Required parameters for the template *Datastream to BigQuery*
 
 | Parameter | Value |
-| ---       | ---   |
+| --- | --- |
 | File location for Datastream file output in Cloud Storage | `gs://${PROJECT_ID}` |
 | The Pub/Sub subscription on the Cloud Storage bucket | `projects/${PROJECT_ID}/subscriptions/cdc_sub` |
 | Datastream output file format (avro/json) | `JSON` |
@@ -133,7 +133,7 @@ Required parameters for the template *Datastream to BigQuery*
 The following optional parameters must be set too.
 
 | Parameter | Value |
-| ---       | ---   |
+| --- | --- |
 | Cloud Storage location of your Javascript UDF | `gs://${PROJECT_ID}-other/js/retail_transform.js` |
 | The name of the JavaScript function you wish to call as your UDF | `process` |
 | Max workers | `5` |


### PR DESCRIPTION
Some of the Github actions used in various workflows were depending on Node 20 which is about to be deprecated, so we're upgrading all actions to use their latest versions (which are based on Node 24). Upgrading markdownlint required some fixes for consistency.