### PR TITLE
Names and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Teams are not left on their own to solve the challenges. Coaches work with each 
 ### Data & AI
 
 - [Introduction to GenAI](./hacks/genai-intro/README.md)
-  > **UPDATED FOR GEMINI** We will build a system to catalog scientific papers. Whenever new papers are uploaded to Cloud Storage a Cloud Function will be triggered and use Vertex AI Foundation Model LLM to extract the title and summarize the paper. We'll store this data in BigQuery and use an LLM directly from BigQuery to classify the papers into distinct categories and then implement semantic search using text embeddings and finally we'll use Vector Search as a scalable solution.
+  > We will build a system to catalog scientific papers. Whenever new papers are uploaded to Cloud Storage a Cloud Function will be triggered and use an LLM (Gemini) to extract the title and summarize the paper. We'll store this data in BigQuery and use the same LLM directly from BigQuery to classify the papers into distinct categories and then implement semantic search using text embeddings and finally we'll use Vector Search as a scalable solution.
 - [MLOps on GCP](./hacks/mlops-on-gcp/README.md)
   > We will be implementing the full lifecycle of an ML project. We'll provide you with a sample code base and you'll work on automating continuous integration (CI), continuous delivery (CD), and continuous training (CT) for a machine learning (ML) system.
 - [Crash Course in AI: Formula E Edition](./hacks/genai-fe/README.md)
@@ -52,10 +52,6 @@ Teams are not left on their own to solve the challenges. Coaches work with each 
   > Learn Docker and GKE with a web application that you can play! You will compose your own Dockerfile to containerize an existing web application and get practice in creating a cluster, creating node pools, and running deployments and services.
 - [Ready, Steady, Cloud Run!](./hacks/cloud-run/README.md)
   > We'll be using Cloud Run to quickly configure, deploy and troubleshoot a web service. During the process we'll introduce different ways to store data for the web service and learn about how to discover and fix issues.
-- [GenAI App Development with Genkit](./hacks/genai-genkit/README.md)
-  > Learn how to create and deploy a GenAI application with Google Cloud and Firebase Genkit.
-- [Monitor GenAI apps with Firebase Genkit](./hacks/genai-monitoring/README.md)
-  > We will be mastering operating Large Language Model applications using Firebase Genkit, and Genkit Monitoring by stepping into the role of Site Reliability Engineers for a fictional GenAI app. We will dive into troubleshooting live issues, fixing issues, and optimizing performance to ensure our GenAI app runs flawlessly.
 - [Practical SRE](./hacks/practical-sre/README.md)
   > In this gHack, you'll step into the role of SREs and Product Owners for a cutting-edge app. Your mission is to ensure that this app delivers a smooth, reliable, and responsive experience for its users.
 

--- a/hacks/adk-intro/README.md
+++ b/hacks/adk-intro/README.md
@@ -71,7 +71,7 @@ Once everything is set up, run `adk web` and make sure that the agent responds b
 - [Cloud Shell](https://cloud.google.com/shell/docs/launching-cloud-shell)
 - [Cloud Shell Editor](https://cloud.google.com/shell/docs/launching-cloud-shell-editor)
 - [Previewing web apps](https://cloud.google.com/shell/docs/using-web-preview)
-- [Setting up authentication for ADK](https://google.github.io/adk-docs/get-started/quickstart/#gemini---google-cloud-vertex-ai)
+- [Setting up authentication for ADK](https://adk.dev/agents/models/google-gemini/#google-cloud-agent-platform)
 
 ### Tips
 

--- a/hacks/genai-fe/README.md
+++ b/hacks/genai-fe/README.md
@@ -95,7 +95,7 @@ Now the source data is available in BigQuery, use BigQuery ML capabilities to ge
 ### Learning Resources
 
 - [Generate multimodal embeddings](https://cloud.google.com/bigquery/docs/generate-multimodal-embeddings)
-- [Latest versions and identifiers of Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#latest_stable_models)
+- [Latest versions and identifiers of Gemini models](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions)
 - [The ML.GENERATE_EMBEDDING function](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding)
 
 ### Tips
@@ -112,9 +112,9 @@ Once we have determined the correct segment, we'll use that for RAG. Retrieval a
 
 ### Description
 
-Design a SQL query that retrieves the **top result** from the embeddings table given the phrase `car crash`. Once you have found the correct video segment, you'll use Vertex AI Studio to extract the exact timestamp of the crash from that video segment.
+Design a SQL query that retrieves the **top result** from the embeddings table given the phrase `car crash`. Once you have found the correct video segment, you'll use Agent Platform Studio to extract the exact timestamp of the crash from that video segment.
 
-Navigate to Vertex AI Studio, *Create Prompt* section, and design a prompt to get the exact timestamp of the crash, using the video segment in your prompt.
+Navigate to Agent Platform Studio and design a prompt to get the exact timestamp of the crash, referencing the video segment you found, in your prompt.
 
 > [!NOTE]  
 > Have a look at the video segment to confirm when the crash happened. You can preview the videos in the Console, just browse to the specific video through Cloud Storage Bucket browser and there will be a button for *Preview*.
@@ -122,17 +122,17 @@ Navigate to Vertex AI Studio, *Create Prompt* section, and design a prompt to ge
 ### Success Criteria
 
 - The SQL query returns the uri for `cam_15_07.mp4`.
-- Vertex AI Studio outputs the exact timestamp of the crash covered in the video segment in `dd/mm/yyyy * HH:MM:SS` format.
+- Agent Platform Studio outputs the exact timestamp of the crash covered in the video segment in `dd/mm/yyyy * HH:MM:SS` format.
 
 ### Learning Resources
 
 - [Generate and search multimodal embeddings](https://cloud.google.com/bigquery/docs/generate-multimodal-embeddings)
-- [Using multimodal prompts in Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding)
+- [Using multimodal prompts in Gemini](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/video-understanding)
 - [What is RAG?](https://cloud.google.com/use-cases/retrieval-augmented-generation)
 
 ### Tips
 
-- In Vertex AI Studio you can use different words to describe the crash (e.g. collision), experiment with those as well as different models/settings. And in case you need additional help with your prompt design, consider the [AI-powered prompt writing](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/ai-powered-prompt-writing).
+- In Agent Platform Studio you can use different words to describe the crash (e.g. collision), experiment with those as well as different models/settings. And in case you need additional help with your prompt design, consider the [AI-powered prompt writing](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/prompts/ai-powered-prompt-writing).
 - The video has the timestamp information in the right format in the top left corner of each frame.
 
 ## Challenge 4: Telemetry to the rescue!

--- a/hacks/genai-fe/solutions.md
+++ b/hacks/genai-fe/solutions.md
@@ -41,7 +41,7 @@ bq mk --location=$REGION -d $BQ_DATASET
 Create a connection and give permission to access the bucket. We're providing the CLI command here, but participants will likely use the console for that, which is fine.
 
 > [!NOTE]  
-> It's possible to create the *connection* from the Console, but it can be confusing as (per the docs) you need to create a Vertex AI connection, which can be used for BigLake and Object Table entities. The creation of the table needs to happen either through `bq` CLI or the SQL editor.
+> It's possible to create the *connection* from the Console, but it can be confusing as (per the docs) you need to create a Agent Platform connection, which can be used for BigLake and Object Table entities. The creation of the table needs to happen either through `bq` CLI or the SQL editor.
 
 ```shell
 CONN_ID=conn
@@ -77,7 +77,7 @@ SELECT COUNT(*) FROM `$BQ_DATASET.videos`
 
 ### Notes & Guidance
 
-In principle the same connection can be used to access Vertex AI models as long as it has the correct permissions, so we're now adding the additional permissions (can be done through the Console too). If participants want to use another connection/service account, that's fine too.
+In principle the same connection can be used to access Agent Platform models as long as it has the correct permissions, so we're now adding the additional permissions (can be done through the Console too). If participants want to use another connection/service account, that's fine too.
 
 ```shell
 gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member="serviceAccount:$SA_CONN" \
@@ -87,7 +87,7 @@ gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member="serviceAc
 > [!NOTE]  
 > It takes a while (1-2 minutes) before the IAM changes are propagated, so if the model creation fails due to lack of permissions even after granting the correct role, just retry after some time.
 
-Now, create the model
+Now, create the model (keep in mind `multimodalembedding@001` is an example and might be end of life by now, use any available embedding model)
 
 ```sql
 CREATE OR REPLACE MODEL `$BQ_DATASET.multimodal_embedding_model`
@@ -175,9 +175,9 @@ LIMIT 1
 > [!NOTE]  
 > If you're wondering about the prefix `base` in the example queries above, it's one of the outputs of the `VECTOR_SEARCH` function that contains all columns from the `base_table` (which is the first argument,`$BQ_DATASET.cctv_embeddings` in this case).
 
-#### Prompt for Vertex AI Studio
+#### Prompt for Agent Platform Studio
 
-In the Vertex AI Studio, in *Create Prompt* section (used to be called Free form), it's possible to add the video segment (`cam_15_07.mp4`) to the prompt through clicking on the media icon (bottom right corner) and choosing `Import from Cloud Storage` option.
+In the Agent Platform Studio, it's possible to add the video segment (`cam_15_07.mp4`) to the prompt through clicking on the media icon (bottom right corner) and choosing `Import from Cloud Storage` option.
 
 The *Prompt* should be something like the following, (where `[cam_15_07.mp4]` is the video segment inserted into the prompt).
 
@@ -192,7 +192,7 @@ And the correct response will be: *11/05/2024 15:42:06* (the exact wording might
 > [!WARNING]  
 > The footage is from a European race, so the time format in the video is `dd/mm/yyyy` and not `mm/dd/yyyy`.
 
-We've succesfully tested this with `gemini-2.0-flash-001` using the default settings, but participants are free to experiment with different models and settings to get the correct answer.
+We've succesfully tested this with `gemini-2.0-flash-001` using the default settings (which is end of life by now), but participants are free to experiment with different available models and settings to get the correct answer.
 
 ## Challenge 4: Telemetry to the rescue!
 

--- a/hacks/genai-intro/README.md
+++ b/hacks/genai-intro/README.md
@@ -10,11 +10,11 @@ Introduction to GenAI will challenge you to build a system that catalogues scien
 
 This hack will help you explore the following tasks:
 
-- Using Vertex AI Foundational models for text understanding
+- Using Gemini for text understanding
 - Prompt engineering
 - Using BigQuery to run LLMs
 - How to use text embeddings for semantic search in BigQuery
-- Vertex AI Vector Search for storing and searching text embeddings
+- Agent Platform Vector Search for storing and searching text embeddings
 
 ## Challenges
 
@@ -90,12 +90,12 @@ For this challenge we'll use Gemini to determine what the title (including any s
 ### Learning Resources
 
 - Using Python [str.format](https://www.w3schools.com/python/ref_string_format.asp)
-- [Prompt Engineering](https://cloud.google.com/vertex-ai/docs/generative-ai/text/text-prompts)
+- [Prompt Engineering](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/prompts/introduction-prompt-design)
 
 ### Tips
 
 - You can edit and redeploy the Cloud Run Function from the Console.
-- You can test your prompts using [Vertex AI Studio](https://cloud.google.com/vertex-ai/docs/generative-ai/text/test-text-prompts#generative-ai-test-text-prompt-console).
+- You can test your prompts using [Agent Platform Studio](https://docs.cloud.google.com/gemini-enterprise-agent-platform/agent-studio/quickstart).
 - You could get the content from PDF files by opening them in PDF reader and copying the text (or if you're very familiar with the CLI and love experimenting with `jq` you can do that by using `gcloud storage cat` & `jq` commands from Cloud Shell by accessing the JSON files in the staging bucket).
 
 ## Challenge 3: Summarizing a large document using chaining
@@ -142,13 +142,13 @@ In order to get the summaries, we'll implement the *Refine* approach for this ch
 ### Learning Resources
 
 - Using Python [str.format](https://www.w3schools.com/python/ref_string_format.asp)
-- [Prompt Engineering](https://cloud.google.com/vertex-ai/docs/generative-ai/text/text-prompts)
+- [Prompt Engineering](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/prompts/introduction-prompt-design)
 
 ## Challenge 4: BigQuery &#10084; LLMs
 
 ### Introduction
 
-So far we've used the Gemini APIs from the Vertex AI Python SDK. It's also possible to use those through BigQuery, this challenge is all about using BigQuery to run an LLM.
+So far we've used the Gemini APIs from the Agent Platform Python SDK. It's also possible to use those through BigQuery, this challenge is all about using BigQuery to run an LLM.
 
 ### Description
 
@@ -262,10 +262,9 @@ Now run the same query as the previous challenge, *Which paper is about characte
 ### Learning Resources
 
 - [BQ Exporting Data](https://cloud.google.com/bigquery/docs/exporting-data#sql)
-- [Vector Search overview](https://cloud.google.com/vertex-ai/docs/vector-search/overview)
-- [Vector Search index data requirements](https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure)
-- [Running a REST query against a public index endpoint](https://cloud.google.com/vertex-ai/docs/vector-search/query-index-public-endpoint)
-- [Quickstart: Build a Python program to query a public index endpoint](https://cloud.google.com/vertex-ai/docs/vector-search/quickstart#run-query)
+- [Vector Search overview](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/overview)
+- [Vector Search index data requirements](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/format-structure)
+- [Running a REST query against a public index endpoint](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search/query-index-public-endpoint#query_public_endpoint-cli)
 
 ### Tips
 

--- a/hacks/genai-intro/solutions.md
+++ b/hacks/genai-intro/solutions.md
@@ -146,7 +146,7 @@ for PDF in *.pdf; do
 done
 ```
 
-Now, we can create the connection to Vertex AI to call the API and make sure that the corresponding service account (that's created after the creation of the connection) has the correct role.
+Now, we can create the connection to Agetn Platform to call the API and make sure that the corresponding service account (that's created after the creation of the connection) has the correct role.
 
 ```shell
 CONN_ID=conn-llm
@@ -348,8 +348,10 @@ In case students use different methods to generate the text embeddings for the s
 See below a Python version of the same code:
 
 ```python
+
+from google import genai
 from google.cloud import aiplatform
-from vertexai.language_models import TextEmbeddingModel
+
 
 # retrieve index endpoint (assuming that there's only one)
 index_endpoint_name = aiplatform.MatchingEngineIndexEndpoint.list()[0].name
@@ -357,9 +359,10 @@ index_endpoint = aiplatform.MatchingEngineIndexEndpoint(index_endpoint_name=inde
 
 # embed the query, note that the model version is an example, use whatever is latest/ga, but make sure that version
 # matches the version which was used from BigQuery to generate the embeddings for the summaries
-model = TextEmbeddingModel.from_pretrained("textembedding-005")  # make sure that the version matches
+model = TextEmbeddingModel.from_pretrained("")  # make sure that the version matches
 query = "Which paper is about characteristics of living organisms in alien worlds?"
-query_embeddings = model.get_embeddings([query])[0]
+client = genai.Client()
+query_embeddings = client.models.embed_content(model="textembedding-005", contents=[query])
 
 # query the index endpoint for the nearest neighbors.
 resp = index_endpoint.find_neighbors(

--- a/hacks/genmedia-on-gcp/README.md
+++ b/hacks/genmedia-on-gcp/README.md
@@ -6,7 +6,7 @@ Welcome to the future of advertising! In this workshop, you'll step into the rol
 
 ![Challenge Overview](./images/easy-ads-overview.png)
 
-This isn't about writing code. It's about mastering the art of the prompt. You will use Google Cloud's generative AI tools within Vertex AI Studio to bring your vision to life. The challenge lies in guiding these models to produce a final ad that is not just aesthetically pleasing, but also **coherent, consistent,** and **on-brand,** complete with **multilingual voice-over**, graphic overlays and a **custom soundtrack**.
+This isn't about writing code. It's about mastering the art of the prompt. You will use Google Cloud's generative AI tools within Agent Platform Studio to bring your vision to life. The challenge lies in guiding these models to produce a final ad that is not just aesthetically pleasing, but also **coherent, consistent,** and **on-brand,** complete with **multilingual voice-over**, graphic overlays and a **custom soundtrack**.
 
 ## Learning Objectives
 
@@ -39,7 +39,7 @@ This hack will help you master the following skills:
 ## Prerequisites
 
 - Basic understanding of generative AI concepts (text-to-image, text-to-video, text-to-speech).  
-- Access to a Google Cloud project with Vertex AI Studio enabled, including access to Gemini, Veo, Chirp, and Lyria models.  
+- Access to a Google Cloud project with Agent Platform Studio enabled, including access to Gemini, Veo, Chirp, and Lyria models.  
 - Access to a basic video editing tool (e.g., Google Vids, DaVinci Resolve, Adobe Premiere Pro, CapCut, iMovie, or any online editor).
 
 ## Contributors
@@ -146,13 +146,13 @@ We've already created a storage bucket for you, make sure that all of this work 
 
 ### Learning Resources
 
-- [Vertex AI Studio Quickstart](https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart)
+- [Agent Platform Studio Quickstart](https://docs.cloud.google.com/gemini-enterprise-agent-platform/agent-studio/quickstart)
 - [Nano Banana Prompting Guide](https://developers.googleblog.com/en/how-to-prompt-gemini-2-5-flash-image-generation-for-the-best-results/)
 
 ### Tips
 
 - If you're in a squeeze for time, you can parallelize the protagonist, product, and logo generation. You'll need both product and protagonist contact sheets to start with the storyboard images though.
-- Keep in mind that some models will have limitations with respect to how many reference images you can include in a prompt and the maximum size. See for example the *Technical Specifications* for [Nano Banana](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image)
+- Keep in mind that some models will have limitations with respect to how many reference images you can include in a prompt and the maximum size. See for example the *Technical Specifications* for [Nano Banana 2](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-image)
 - There are also limits in the Media Studio UI, you might want to use the Import from Cloud Storage options instead of uploading your images in your prompt
 
 ## Challenge 3: From Stills to Motion
@@ -163,7 +163,7 @@ With your storyboard and protagonist created, it's time to bring your vision to 
 
 ### Description
 
-Using the *Veo* family of models in Vertex AI Studio, generate video clips for each of your storyboard scenes from Challenge 2. Make sure you use your generated images as references in your prompts to guide the model.
+Using the *Veo* family of models in Agent Platform Studio, generate video clips for each of your storyboard scenes from Challenge 2. Make sure you use your generated images as references in your prompts to guide the model.
 
 > [!IMPORTANT]  
 > It's fine to have background sound or noises for some parts of your video, but keep in mind that you'll be generating voice-overs in a later challenge. Also, if you need to have dialog that syncs with lips on the screen, that needs to be done during video creation time.
@@ -182,7 +182,7 @@ Once finished, store your favorite clips for each scene in the storage bucket pr
 
 ### Learning Resources
 
-- [Generate videos with Veo](https://cloud.google.com/vertex-ai/docs/generative-ai/video/generate-videos)
+- [Generate videos with Veo](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/overview)
 - [Veo Prompting Guide](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-veo-3-1)
 
 ### Tips
@@ -227,7 +227,7 @@ First, write a short, compelling script for your ad. The script should consist o
 > [!NOTE]  
 > Once again, Gemini is fair game to generate the script, but you're also free to use your own writing creativity.
 
-Next, use the *Chirp 3 HD* model in Vertex AI or the *Gemini TTS* model to generate the voice-overs from your script. Choose one of the voice-overs and generate it in a foreign language, (e.g. Italian, Afrikaans, Turkish).
+Next, use the Agent Platform *Chirp 3 HD* model or the *Gemini TTS* model to generate the voice-overs from your script. Choose one of the voice-overs and generate it in a foreign language, (e.g. Italian, Afrikaans, Turkish).
 
 Finally, add these audio tracks to the video you assembled in Challenge 4 in the proper places in your video sequence timeline.
 
@@ -250,7 +250,7 @@ Music is an important layer of emotion in your ad. To complete your masterpiece,
 
 ### Description
 
-Using the *Lyria* model in Vertex AI, generate a music track for the entire ad. Remember to adhere to your brand guidelines.
+Using the Agent Platform *Lyria* model, generate a music track for the entire ad. Remember to adhere to your brand guidelines.
 
 Once you have a track you're happy with, add it as a final audio layer to your video sequence timeline. Make sure to balance the volume so that the music complements the voice-overs without overpowering them.
 

--- a/hacks/genmedia-on-gcp/solutions.md
+++ b/hacks/genmedia-on-gcp/solutions.md
@@ -22,7 +22,7 @@ Welcome to the coach's guide for the *Easy Ads: From Concept to Creation with Ge
 
 ### Notes & Guidance
 
-If the participants are using Vertex AI Studio for generating the story, they should turn on auto-save. This way they can keep track of their progress and easily hand over the generated descriptions to the next driver.
+If the participants are using Agent Platform Studio for generating the story, they should turn on auto-save. This way they can keep track of their progress and easily hand over the generated descriptions to the next driver.
 
 > [!NOTE]  
 > As mentioned in the instructions using Gemini is fair game, but using the first best response might lead to generic outputs, so adding a bit of creativity, or a few more iterations, would make the end results better.
@@ -55,7 +55,7 @@ We're expecting *at least* three scenes, but it makes sense to have more (and sh
 
 ### Notes & Guidance
 
-The idea is that the participants should use the descriptions from Challenge 1, and use either Gemini or *Help me write* capabilities with Vertex AI Media Studio to generate the required prompts. Nano Banana can be used to create the original images as well as to generate the different angles.
+The idea is that the participants should use the descriptions from Challenge 1, and use either Gemini or *Help me write* capabilities with Agent Platform Studio to generate the required prompts. Nano Banana can be used to create the original images as well as to generate the different angles.
 
 > [!IMPORTANT]  
 > Participants should try to stay away from *Imagen* family of models, these are not well suited for this task. *Gemini Native Image* (aka: *Nano Banana*) is the recommended model.
@@ -63,7 +63,7 @@ The idea is that the participants should use the descriptions from Challenge 1, 
 For the storyboard scene generation again Nano Banana would be the best fit. They can start uploading the relevant protagonist and product pictures together with the text of the their storyboard scene (maybe optimized through Gemini or *Help me write* capabilities) to generate the images.
 
 > [!WARNING]  
-> At the time of this writing Nano Banana in Vertex AI Media Studio has a limit of 10MB, so if there are too many images inserted in a single conversation, things will fail. Also there are limits to how many images can be included in a single prompt (3 for Nano Banana at the moment), if the participants go beyond that limit, Nano Banana will silently ignore those. Participants should use multiple conversations and/or fewer images.
+> At the time of this writing Nano Banana in Agent Platform Studio has a limit of 10MB, so if there are too many images inserted in a single conversation, things will fail. Also there are limits to how many images can be included in a single prompt (3 for Nano Banana at the moment), if the participants go beyond that limit, Nano Banana will silently ignore those. Participants should use multiple conversations and/or fewer images.
 
 #### Pro Tips for the Students
 
@@ -86,7 +86,7 @@ There's a plethora of different options here, participants can use the story boa
 - Video generation is time-intensive. To optimize efficiency, we recommend that **two or three team members simultaneously generate distinct video sets**. Afterwards, compare and select the most effective clips, or regenerate as necessary. Do not delay progress.
 - For enhanced consistency, consider **utilizing a screenshot of the final frame** from Video 1 as the initiating frame for Video 2.
 - Upload **3-5** images and detailed descriptions.
-- Can't emphasize enough to go through this guide [Veo on Vertex AI video generation prompt guide](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/video/video-gen-prompt-guide). This separates a great shot from a good shot.
+- Can't emphasize enough to go through this guide [Veo on Agent Platform video generation prompt guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/video-gen-prompt-guide). This separates a great shot from a good shot.
 - Google Models take IP and Safety very seriously. Do not use any known persons, products, films, references, likeness or names. Safety filter will trigger if Gemini detects such references in the prompt.
 - If you see your character develop discrepancies between scenes, like their look changes, go back to the previous challenge and develop better images.
 - Also if certain actions are not consistent (opening doors differently), include reference images for those.

--- a/hacks/httf-data/README.md
+++ b/hacks/httf-data/README.md
@@ -214,23 +214,23 @@ Using the embeddings model in Spanner do a search for the query *Luxury items fo
 
 ### Introduction
 
-Now we have product descriptions, we can generate images based on these descriptions using GenAI. This will involve running a Vertex AI Pipeline to orchestrate a few things, such as iterating over the data, preparing the prompt based on the product description, running *Imagen* to generate the images, pick one of the results (randomly), store the image in Cloud Storage and record the URI in BigQuery.
+Now we have product descriptions, we can generate images based on these descriptions using GenAI. This will involve running a Agent Platform Pipeline to orchestrate a few things, such as iterating over the data, preparing the prompt based on the product description, running *Imagen* to generate the images, pick one of the results (randomly), store the image in Cloud Storage and record the URI in BigQuery.
 
 ### Description
 
 Create a new Cloud Storage bucket and name it `{YOUR PROJECT ID}-images`.  Update the BigQuery `products` table to include `image_uri` and `image_url` columns.
 
-We've already prepared the code for a Vertex AI Pipeline, download it from [here](https://github.com/meken/gcp-httf-data-kfp/archive/refs/heads/main.zip) and install its dependencies. Then run the code, it will create a `yaml` file. Navigate to Vertex AI Pipelines and *Create run* with that `yaml` file, provide the required parameters and submit the job.
+We've already prepared the code for a Agent Platform Pipeline, download it from [here](https://github.com/meken/gcp-httf-data-kfp/archive/refs/heads/main.zip) and install its dependencies. Then run the code, it will create a `yaml` file. Navigate to Agent Platform Pipelines and *Create run* with that `yaml` file, provide the required parameters and submit the job.
 
 ### Success Criteria
 
 - There's a new Cloud Storage bucket called `{YOUR PROJECT ID}-images`.
 - The BigQuery `products` table has the new columns `image_uri` and `image_url`.
-- The provided Vertex AI Pipeline has been successfully run.
+- The provided Agent Platform Pipeline has been successfully run.
 - There are product images generated for the `products` and the corresponding urls are in the BigQuery table.
 
 ### Learning Resources
 
 - [Creating new Cloud Storage Buckets](https://cloud.google.com/storage/docs/creating-buckets)
 - [Modifying table schemas in BigQuery](http://cloud.google.com/bigquery/docs/managing-table-schemas)
-- [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines/introduction)
+- [Running Agent Platform Pipelines](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/pipelines/run-pipeline)

--- a/hacks/httf-data/solutions.md
+++ b/hacks/httf-data/solutions.md
@@ -442,7 +442,7 @@ pip install -r requirements.txt
 python3 genai-imagen-pipeline.py
 ```
 
-Easiest option to make the generated `yaml` file to Vertex AI Pipelines is to upload it to the newly created bucket.
+Easiest option to make the generated `yaml` file to Agent Platform Pipelines is to upload it to the newly created bucket.
 
 ```shell
 gcloud storage cp image-generation-pipeline.yaml $BUCKET

--- a/hacks/media-on-gcp/README.md
+++ b/hacks/media-on-gcp/README.md
@@ -73,9 +73,9 @@ Using Google Cloud's Generative Media offerings can make quick work of ad creati
 
 You will work as a team and get creative to come up with an imaginary product. Then use your creativity to create an ad for that product.
 
-In the Google Cloud Console and find **Media Studio** within the **Vertex AI** suite.
+In the Google Cloud Console and find **Studio** within the **Agent Platform** suite.
 
-In the **Media Studio** you have access to the generative AI creative tooling.
+In the **Agent Platform Studio** you have access to the generative AI creative tooling.
 
 - Use Veo to create shots.
 - Use Imagen to create still images.
@@ -114,9 +114,9 @@ Install the client and then use the credentials provided by your coach to log in
 
 ### Learning Resources
 
-- [Veo video generation overview](https://cloud.google.com/vertex-ai/generative-ai/docs/video/overview)
-- [Imagen image generation overview](https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview)
-- [Lyra music generation overview](https://cloud.google.com/vertex-ai/generative-ai/docs/music/generate-music)
+- [Veo video generation overview](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/overview)
+- [Imagen image generation overview](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/image-generation)
+- [Lyra music generation overview](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/music/overview)
 - [DaVince Resolve Beginners Guide Video (13 min)](https://youtu.be/SzttF-qnqsM)
 - [DaVinci Resolve New Features Guide](https://documents.blackmagicdesign.com/SupportNotes/DaVinci_Resolve_20_New_Features_Guide.pdf)
 - [HP Anywhere PCoIP Downloads](https://anyware.hp.com/find/product/hp-anyware)
@@ -358,7 +358,7 @@ Now we need to get a **Gemini API Key**
 - On that same page, create credentials of type: **API key**
 - Provide a name for your api key : example - Gemini API Key
 - In API restrictions section, click radio button Restrict Key
-- In the filter select Generative Language API and Vertex AI
+- In the filter select Generative Language API and Agent Platform
 - A new API is created, save this key, you'll be using it soon.
 
 Next we will deploy and run the pipeline

--- a/hacks/mlops-on-gcp/README.md
+++ b/hacks/mlops-on-gcp/README.md
@@ -37,7 +37,7 @@ This hack will help you explore the following tasks:
 
 - Using Cloud Source Repositories for version control
 - Using Cloud Build for automating continuous integration and delivery
-- Vertex AI for
+- Agent Platform (formerly known as Vertex AI) for
   - Exploration through an interactive environment
   - Training on diverse hardware
   - Model registration
@@ -70,38 +70,40 @@ This hack will help you explore the following tasks:
 
 ### Introduction
 
-As depicted in the overview diagram, the first step of any ML project is data analysis and maybe some experimentation. Jupyter notebooks are great for interactive exploration. We can run those locally, but Vertex AI provides managed environments where you get to run Jupyter with the right security controls and flexible hardware options.
+As depicted in the overview diagram, the first step of any ML project is data analysis and maybe some experimentation. Jupyter notebooks are great for interactive exploration. We can run those locally, but Gemini Enterprise Agent Platform (formerly known as Vertex AI) provides managed environments where you get to run Jupyter with the right security controls and flexible hardware options.
+
+> [!IMPORTANT] Vertex AI has been renamed to Gemini Enterprise Agent Platform. All of the functionality used in this and the following challenges can be found under the Models and Notebooks sections of Agent Platform.
 
 ### Description
 
-Create a *Vertex AI Workbench Instance*. Pick a region close to you and choose the **single user only** option.
+Create a *Workbench Instance*. Pick a region close to you and choose the **single user only** option.
 
 It's a good practice to have isolated virtual environments for experiments, so create a new virtual environment and install that as a kernel. See this [gist](https://gist.github.com/meken/e6c7430997de9b3f2cf7721f8ecffc04) for the instructions.
 
 > [!WARNING]  
-> Not using a dedicated and isolated environment/kernel might cause dependency conflicts as Vertex AI Workbench Instances come pre-installed with some versions of the required libraries.
+> Not using a dedicated and isolated environment/kernel might cause dependency conflicts as Workbench Instances come pre-installed with some versions of the required libraries.
 
-We've prepared a [sample project on Github](https://github.com/meken/gcp-mlops-demo/archive/refs/heads/main.zip), navigate there and download the project as a **zip** file and extract the contents of the zip file onto your Notebook instance. Open the notebook `01-tip-toe-vertex-ai.ipynb`, make sure that you've selected the newly created kernel. You should now be able to run the first notebook and get familiar with some of the Vertex AI concepts.
+We've prepared a [sample project on Github](https://github.com/meken/gcp-mlops-demo/archive/refs/heads/main.zip), navigate there and download the project as a **zip** file and extract the contents of the zip file onto your Notebook instance. Open the notebook `01-tip-toe-vertex-ai.ipynb`, make sure that you've selected the newly created kernel. You should now be able to run the first notebook and get familiar with some of the Agent Platform concepts.
 
 > [!NOTE]  
 > As we're installing packages in the first cell of the sample notebook and restarting the kernel in one of the following cells, *Run All* will not work. Run the cells one-by-one also to understand what's going on in every cell.
 
 ### Success Criteria
 
-1. There's a new single-user Vertex AI Workbench Instance.
+1. There's a new single-user Workbench Instance.
 2. The sample notebook `01-tip-toe-vertex-ai.ipynb` is successfully run (using the newly generated kernel) and a model file is generated/stored in Google Cloud Storage.
 3. No code was modified.
 
 ### Tips  
 
-- Some of the required settings can be found in the *Advanced Settings* section when you're creating a new Vertex AI Workbench Instance.
+- Some of the required settings can be found in the *Advanced Settings* section when you're creating a new Workbench Instance.
 - If there's nothing mentioned in the instructions about a parameter, stick to the defaults (this applies to all of the challenges).
 - You can download the zip file to your local machine and then upload it to the Notebook instance, but you can also get the zip URL and use the `wget` (or `curl`) command from a terminal on the Notebook instance.
 - The sample notebook creates a bucket in a specific *region*, take note of that as you'll need that information in the next challenges.
 
 ### Learning Resources
 
-- Documentation on [Vertex AI Workbench Instances](https://cloud.google.com/vertex-ai/docs/workbench/instances/introduction)
+- Documentation on [Workbench Instances](https://docs.cloud.google.com/gemini-enterprise-agent-platform/notebooks/workbench/introduction)
 
 ## Challenge 2: If it isn't in version control, it doesn't exist
 
@@ -114,7 +116,7 @@ The objective of this challenge is to create and configure a Git repository so t
 
 ### Description
 
-If you have completed the previous challenge, you should have the source code already unpacked on your Vertex AI Workbench Instance (if another user is driving this challenge, see the tips). But you're free to complete this challenge on another environment such as Cloud Shell or even on your local machine.
+If you have completed the previous challenge, you should have the source code already unpacked on your Workbench Instance (if another user is driving this challenge, see the tips). But you're free to complete this challenge on another environment such as Cloud Shell or even on your local machine.
 
 Create a Cloud Source Repository, configure access through **SSH**.
 
@@ -129,9 +131,9 @@ Make sure that the source code is pushed to the freshly created repository and c
 
 ### Tips
 
-- The previous challenge required you to use a single-user Vertex AI Workbench Instance, so if you want to complete this challenge in a Vertex AI Workbench Instance as a different user, you'll have to create a new instance. In that case create another single-user Vertex AI Workbench Instance for the new user and download the repository (zip file). You don't need to run the provided sample notebook or create the virtual environment for this challenge.
+- The previous challenge required you to use a single-user Workbench Instance, so if you want to complete this challenge in a Workbench Instance as a different user, you'll have to create a new instance. In that case create another single-user Workbench Instance for the new user and download the repository (zip file). You don't need to run the provided sample notebook or create the virtual environment for this challenge.
 - Alternatively you could use the Cloud Shell to complete this challenge.
-- Both Vertex AI Workbench Instances and Cloud Shell have OpenSSH already installed
+- Both Workbench Instances and Cloud Shell have OpenSSH already installed
 
 ### Learning Resources
 
@@ -169,11 +171,11 @@ Once things look fine locally, set up a *Cloud Build Trigger* that's run when co
 
 ### Introduction
 
-The previous challenge introduced the concept of build pipelines. But there are different types of pipelines, and this task is getting started with Vertex AI pipelines for *Continuous Training*. In our example the continuous training pipeline will extract data from BigQuery, validate it, prepare it, train a model with it (using the Python package that's built during the previous challenge), evaluate that model and register it in Vertex AI Model Registry.
+The previous challenge introduced the concept of build pipelines. But there are different types of pipelines, and this task is getting started with Agent Platform Pipelines for *Continuous Training*. In our example the continuous training pipeline will extract data from BigQuery, validate it, prepare it, train a model with it (using the Python package that's built during the previous challenge), evaluate that model and register it in Agent Platform Model Registry.
 
 ### Description
 
-If you've successfully completed the previous challenge, your training code has been packaged and can be run from a Vertex AI pipeline.
+If you've successfully completed the previous challenge, your training code has been packaged and can be run from a Agent Platform Pipeline.
 
 The provided project has a `pipeline.py` file that can generate a pipeline definition. Run that to generate a pipeline definition file in `YML` format. Use the generated pipeline definition file to create a new *Pipeline Run* through the GCP Console. Fill in the required pipeline parameters in the next step (you can look up the Python package location). Do not set/override the `endpoint` and `monitoring_job` parameters (keep the default values).
 
@@ -182,7 +184,7 @@ The provided project has a `pipeline.py` file that can generate a pipeline defin
 
 ### Success Criteria
 
-1. There's at least one successful Vertex AI pipeline run that has generated a Managed Model in the Model Registry.
+1. There's at least one successful Agent Platform Pipeline run that has generated a Managed Model in the Model Registry.
 2. No code was modified.
 
 ### Tips
@@ -197,7 +199,7 @@ The provided project has a `pipeline.py` file that can generate a pipeline defin
 
 ### Learning Resources
 
-- Running [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines/run-pipeline#console) on the console
+- Running [Agent Platform Pipelines](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/pipelines/run-pipeline) on the console
 
 ## Challenge 5: Make it work and make it scale
 
@@ -219,9 +221,9 @@ From this challenge onwards you'll have the option to either do online inferenci
 
 ### Description
 
-So, you've chosen for online inferencing. In order to use the model to serve predictions in an online fashion it has to be deployed to an endpoint. Luckily Vertex AI provides exactly what we need, a managed service for serving predictions, called Online Prediction.
+So, you've chosen for online inferencing. In order to use the model to serve predictions in an online fashion it has to be deployed to an endpoint. Luckily Agent Platform provides exactly what we need, a managed service for serving predictions, called Online Prediction.
 
-Create a new Vertex AI Endpoint and deploy the freshly trained model. Use the smallest machine type but make sure that it can scale to more than 1 node by configuring *autoscaling*.
+Create a new Agent Platform Endpoint and deploy the freshly trained model. Use the smallest machine type but make sure that it can scale to more than 1 node by configuring *autoscaling*.
 
 > [!NOTE]  
 > The deployment of the model will take ~10 minutes to complete.
@@ -242,14 +244,14 @@ Create a new Vertex AI Endpoint and deploy the freshly trained model. Use the sm
 
 ### Learning Resources
 
-- Documentation on [Online Predictions deployment](https://cloud.google.com/vertex-ai/docs/general/deployment)
-- More info on the [request data format](https://cloud.google.com/vertex-ai/docs/predictions/get-online-predictions). Remember that we've used the `scikit-learn` framework to train our model.
+- Documentation on [Online Predictions deployment](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/general/deployment)
+- More info on the [request data format](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/get-online-predictions#scikit-learn). Remember that we've used the `scikit-learn` framework to train our model.
 
 ### Batch Inferencing
 
 ### Description
 
-So, you've chosen for the batch inferencing path. We're going to use Vertex AI Batch Predictions to get predictions for data in a BigQuery table. First, go ahead and create a new table with at most 10K rows that's going to be used for generating the predictions. Once the table is created, create a new Batch Prediction job with that table as the input and another BigQuery table as the output, using the previously created model. Choose a small machine type and 2 compute nodes. Don't turn on Model Monitoring yet as that's for the next challenge.
+So, you've chosen for the batch inferencing path. We're going to use Agent Platform Batch Predictions to get predictions for data in a BigQuery table. First, go ahead and create a new table with at most 10K rows that's going to be used for generating the predictions. Once the table is created, create a new Batch Prediction job with that table as the input and another BigQuery table as the output, using the previously created model. Choose a small machine type and 2 compute nodes. Don't turn on Model Monitoring yet as that's for the next challenge.
 
 > [!NOTE]  
 > The batch inferencing will take roughly ~10 minutes, most of that is the overhead of starting the cluster, so increasing the number of instances won't help with the small table we're using.
@@ -271,7 +273,7 @@ So, you've chosen for the batch inferencing path. We're going to use Vertex AI B
 - Creating BigQuery [datasets](https://cloud.google.com/bigquery/docs/datasets)
 - Creating BigQuery [tables](https://cloud.google.com/bigquery/docs/tables#sql)
 - BigQuery [public datasets](https://console.cloud.google.com/marketplace/details/city-of-new-york/nyc-tlc-trips)
-- Vertex AI [Batch Predictions](https://cloud.google.com/vertex-ai/docs/tabular-data/classification-regression/get-batch-predictions)
+- Agent Platform [Batch Predictions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/predictions/get-batch-predictions)
 
 ## Challenge 6: Monitor your models
 
@@ -280,7 +282,7 @@ So, you've chosen for the batch inferencing path. We're going to use Vertex AI B
 There are times when the training data becomes not representative anymore because of changing demographics, trends etc. To catch any skew or drift in feature distributions or even in predictions, it is necessary to monitor your model performance continuously.
 
 > [!NOTE]  
-> We'll be using *Model Monitoring v1* for this challenge, which is configured during *Online Prediction Endpoint configuration* for online models, and *Batch Prediction Run configuration* for batch execution.
+> We'll be using **Model Monitoring v1** for this challenge, which is configured during *Online Prediction Endpoint configuration* for online models, and *Batch Prediction Run configuration* for batch execution.
 
 If you've chosen the online inferencing path, continue with [Online Monitoring](#online-monitoring), otherwise please skip to the [Batch Monitoring](#batch-monitoring) section.
 
@@ -288,7 +290,7 @@ If you've chosen the online inferencing path, continue with [Online Monitoring](
 
 ### Description
 
-Vertex AI Endpoints provide Model Monitoring capabilities which will be configured for this challenge. Turn on Training-serving skew detection for your model and use an hourly granularity to get alerts. Create a new notification channel that uses Pub/Sub messages and configure it to use a new Pub/Sub topic.
+Agent Platform Endpoints provide Model Monitoring capabilities which will be configured for this challenge. Turn on Training-serving skew detection for your model and use an hourly granularity to get alerts. Create a new notification channel that uses Pub/Sub messages and configure it to use a new Pub/Sub topic.
 
 Send at least 10K prediction requests to collect monitoring data.
 
@@ -306,7 +308,7 @@ Send at least 10K prediction requests to collect monitoring data.
 
 ### Learning Resources
 
-- Introduction to [Vertex AI Model Monitoring](https://cloud.google.com/vertex-ai/docs/model-monitoring/overview)
+- Introduction to [Agent Platform Model Monitoring](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/model-monitoring/overview)
 - Creating a [Pub/Sub topic](https://cloud.google.com/pubsub/docs/create-topic)
 - Creating a [notification channel](https://cloud.google.com/monitoring/support/notification-options#pubsub)
 
@@ -314,7 +316,7 @@ Send at least 10K prediction requests to collect monitoring data.
 
 ### Description
 
-Vertex AI Batch prediction jobs provide Model Monitoring capabilities as well. Create a new Batch Predition job with monitoring turned on with BigQuery input and ouput tables, use default values for the alert thresholds. Create a new notification channel that uses Pub/Sub messages and configure it to use a new Pub/Sub topic.
+Agent Platform Batch prediction jobs provide Model Monitoring capabilities as well. Create a new Batch Predition job with monitoring turned on with BigQuery input and ouput tables, use default values for the alert thresholds. Create a new notification channel that uses Pub/Sub messages and configure it to use a new Pub/Sub topic.
 
 ### Success Criteria
 
@@ -330,7 +332,7 @@ Vertex AI Batch prediction jobs provide Model Monitoring capabilities as well. C
 
 ### Learning Resources
 
-- [Model monitoring](https://cloud.google.com/vertex-ai/docs/model-monitoring/model-monitoring-batch-predictions) for Batch Predictions
+- [Model monitoring](https://docs.cloud.google.com/gemini-enterprise-agent-platform/machine-learning/model-monitoring/model-monitoring-batch-predictions) for Batch Predictions
 - Creating a [Pub/Sub topic](https://cloud.google.com/pubsub/docs/create-topic)
 - Creating a [notification channel](https://cloud.google.com/monitoring/support/notification-options#pubsub)
 
@@ -370,7 +372,7 @@ Use the provided build pipeline (`clouddeploy.yaml`) to create a new build confi
 
 ### Description
 
-Typically Batch Predictions are asynchronous and are scheduled to run periodically (daily/weekly etc). You can trigger batch jobs using different methods, for this challenge we'll use Cloud Build pipelines in combination with Vertex AI pipelines. Create a new Cloud Build trigger using the provided `batchdeploy.yaml` file, don't forget to set the required variables. Call this trigger `CD` (or `continuous-delivery`) and make sure that this build pipeline is triggered through webhook events. Create a new Cloud Scheduler job that runs every Sunday at 3:30 and uses the webhook event URL as the execution method.
+Typically Batch Predictions are asynchronous and are scheduled to run periodically (daily/weekly etc). You can trigger batch jobs using different methods, for this challenge we'll use Cloud Build pipelines in combination with Agent Platform Pipelines. Create a new Cloud Build trigger using the provided `batchdeploy.yaml` file, don't forget to set the required variables. Call this trigger `CD` (or `continuous-delivery`) and make sure that this build pipeline is triggered through webhook events. Create a new Cloud Scheduler job that runs every Sunday at 3:30 and uses the webhook event URL as the execution method.
 
 Running the batch predictions periodically will only get us half way. We need to monitor any Model Monitoring alerts and act on that. There's another Cloud Build pipeline definition provided by `clouddeploy.yaml` that's responsible for retraining. Configure that in a new Cloud Build trigger, call it `CT` (or `continuous-training`) set the required variables (remember to set *ENDPOINT* to `[none]`, the others should be familiar, when in doubt have a look at the yaml file). Use Pub/Sub messages as the trigger event and pick the topic that's configured for Model Monitoring Pub/Sub notification channel.
 

--- a/hacks/mlops-on-gcp/solutions.md
+++ b/hacks/mlops-on-gcp/solutions.md
@@ -20,9 +20,9 @@ We'll be assuming that all necessary services have been enabled and the (default
 
 ### Notes & Guidance
 
-The Vertex AI Workbench Instance can run anywhere, but a region close to the participants is preferred. And the *Permissions*&rarr;*Single user only* option must be chosen, which requires to enter the Advanced Setting section for Vertex AI Workbench Instance.
+The Workbench Instance can run anywhere, but a region close to the participants is preferred. And the *Permissions*&rarr;*Single user only* option must be chosen, which requires to enter the Advanced Setting section for Workbench Instance.
 
-Creating a virtual environment is essential otherwise things might break due to dependency conflicts. The instructions point to a gist that works with `pip` and Vertex AI Workbench Instances have that installed. However, `conda` virtual environments would work fine too. Make sure to run these from a *Terminal* in Jupyter (not from a *Notebook*)!
+Creating a virtual environment is essential otherwise things might break due to dependency conflicts. The instructions point to a gist that works with `pip` and Workbench Instances have that installed. However, `conda` virtual environments would work fine too. Make sure to run these from a *Terminal* in Jupyter (not from a *Notebook*)!
 
 ```shell
 python3 -m venv .playground
@@ -124,7 +124,7 @@ Alternatively they could also run `python src/trainer/pipeline.py` as the module
 
 The generated json file can be copied to the default GCS bucket (created as part of the first challenge) or downloaded locally.
 
-The parameters for the Vertex AI Pipeline Job:
+The parameters for the Agent Platform Pipeline Job:
 
 | Parameter            | Value                              |
 | ---                  | ---                                |


### PR DESCRIPTION
Updated references to Vertex AI, called Gemini Enterprise Agent Platform now. Also removed the obsolete Genkit gHacks from the front page, content is kept in case we decide to update them.